### PR TITLE
Bump hexbytes dependency 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 gevent==21.12.0
-hexbytes==0.2.2
+hexbytes==1.3.1
 boto3==1.24.17
 python-dotenv==0.19.2
 requests==2.27.1
-web3 @ git+https://github.com/ethereum/web3.py@c68f6564ef85c17c5162ce2493d6db16e755516c
+web3==7.2.0
 aws-lambda-typing==2.13.0
 simplejson==3.17.6

--- a/src/lib/helpers/aws.py
+++ b/src/lib/helpers/aws.py
@@ -22,7 +22,7 @@ def upload_abi_data(_type: str, signature: HexBytes, abi_method: str) -> None:
     assert (
         abi_table.put_item(
             Item={
-                "PK": f"{_type}#{signature.hex()}",
+                "PK": f"{_type}#{signature.to_0x_hex()}",
                 "SK": abi_method,
             }
         )["ResponseMetadata"]["HTTPStatusCode"]
@@ -43,7 +43,7 @@ def upload_abi_data_contract(
         abi_table.put_item(
             Item={
                 "PK": f"contract#{chain.lower()}#{address.lower()}",
-                "SK": f"{_type}#{signature.hex()}",
+                "SK": f"{_type}#{signature.to_0x_hex()}",
                 "verbose_abi": verbose_abi,
             }
         )["ResponseMetadata"]["HTTPStatusCode"]
@@ -61,9 +61,7 @@ def get_abi_data(_type: str, signature: HexBytes):
 
     res: Dict[str, List[str]] = defaultdict(list)
 
-    ret = abi_table.query(
-        KeyConditionExpression=Key("PK").eq(f"{_type}#{signature.hex()}")
-    )
+    ret = abi_table.query(KeyConditionExpression=Key("PK").eq(f"{_type}#{signature.to_0x_hex()}"))
 
     if _type == "event":
         # If more than 1 then there is a colliso - uh oh.
@@ -96,10 +94,8 @@ def get_abi_data_contract(
         assert len(signature) == 32  # Topic hash.
 
     ret = abi_table.query(
-        KeyConditionExpression=Key("PK").eq(
-            f"contract#{chain.lower()}#{address.lower()}"
-        )
-        & Key("SK").eq(f"{_type}#{signature.hex()}")
+        KeyConditionExpression=Key("PK").eq(f"contract#{chain.lower()}#{address.lower()}")
+        & Key("SK").eq(f"{_type}#{signature.to_0x_hex()}")
     )
 
     # Should only be no more than 1 result for both functions and events.
@@ -130,7 +126,7 @@ def get_abi_data_pseudo_batch(_type: str, _signatures: List[HexBytes]):
 
         if res:
             for _sig, _res in res.items():
-                assert sig.hex() == _sig
+                assert sig.to_0x_hex() == _sig
 
                 if _type == "function":
                     ret[_sig].extend(_res)
@@ -138,7 +134,7 @@ def get_abi_data_pseudo_batch(_type: str, _signatures: List[HexBytes]):
                     ret[_sig] = _res
         else:
             # `defaultdict(list)` will init an empty list.
-            ret[sig.hex()]
+            ret[sig.to_0x_hex()]
 
     return ret
 
@@ -169,9 +165,9 @@ def get_abi_data_contract_pseudo_batch(
 
         if res:
             for _sig, _res in res.items():
-                assert sig.hex() == _sig
+                assert sig.to_0x_hex() == _sig
                 ret[_sig] = _res
         else:
-            ret[sig.hex()] = None
+            ret[sig.to_0x_hex()] = None
 
     return ret

--- a/src/server/fetch.py
+++ b/src/server/fetch.py
@@ -55,7 +55,7 @@ def fetch_contract(event: APIGatewayEvent, context: Context):
 
         # Okay, I may be a *bit* stupid and forgot to include the `0x` prefix
         # in the database keys...
-        address = HexBytes(address).hex()[2:]
+        address = HexBytes(address).hex()
 
         res = {}
 


### PR DESCRIPTION
Bump the `hexbytes` dependency from version 0.2.2 to 1.3.1. This PR includes a refactor of all uses of the `.hex` method, which dropped the "0x" prefix starting at version 1.0.0. See the [hexbytes release notes](https://hexbytes.readthedocs.io/en/stable/release_notes.html) for a description of the breaking change and the new `to_0x_hex` method.

The web3.py dependency has also been upgraded to 7.2.0, which [included a bugfix](https://github.com/ethereum/web3.py/blob/main/docs/release_notes.rst#web3py-v720-2024-08-29) for that same change.